### PR TITLE
don't at role changes

### DIFF
--- a/lib/commands/botCommands.js
+++ b/lib/commands/botCommands.js
@@ -6,7 +6,7 @@ const source = require('rfr');
 const { pingCommand } = source('lib/commands/ping');
 const { helpCommand } = source('lib/commands/help');
 const { helpAdminCommand } = source('lib/commands/helpAdmin');
-const { changeRoleCommand } = source('lib/commands/changeRole');
+const { changeRoleCommand, giveRoleCommand } = source('lib/commands/changeRole');
 const { redditCommand, memeCommand, puppyCommand, cuteCommand } = source('lib/commands/redditPost');
 const { mentalHealthCommand } = source('lib/commands/mentalHealth');
 const { weatherCommand } = source('lib/commands/weather');
@@ -47,6 +47,10 @@ function commandHandler(message) {
                 changeRoleCommand(message, 'add');
             } else if (containsCommand(message, commandPrompt, 'remove')) {
                 changeRoleCommand(message, 'remove');
+            } else if (containsCommand(message, commandPrompt, 'give')) {
+                giveRoleCommand(message, 'add');
+            } else if (containsCommand(message, commandPrompt, 'revoke')) {
+                giveRoleCommand(message, 'remove');
             } else if (containsCommand(message, commandPrompt, 'keeb')) {
                 keebCommand(message);
             } else if (containsCommand(message, commandPrompt, 'reddit')) {

--- a/lib/commands/changeRole.js
+++ b/lib/commands/changeRole.js
@@ -3,7 +3,7 @@
 
 const source = require('rfr');
 
-const { filterRole, lookupRoleName, discardCommand } = source('lib/commands/commandUtilities');
+const { filterRole, lookupRoleName, discardFirst, splitStringBySpace, getMember } = source('lib/commands/commandUtilities');
 const { sendMessage } = source('lib/utils/util');
 const { changeRole } = source('lib/roles/roles');
 
@@ -16,7 +16,7 @@ function sendRoleConfirmation(channel, role, user, mode) {
 }
 
 function changeRoleCommand(message, mode) {
-    const roleName = discardCommand(message.content);
+    const roleName = discardFirst(message.content);
     const { member } = message;
     const role = filterRole(lookupRoleName(message.guild, roleName));
 
@@ -30,4 +30,25 @@ function changeRoleCommand(message, mode) {
     }
 }
 
-exports.changeRoleCommand = changeRoleCommand;
+function giveRoleCommand(message, mode) {
+    const text = discardFirst(message.content);
+    const memberText = splitStringBySpace(text)[0];
+    const roleName = discardFirst(text);
+
+    const member = getMember(message.guild, memberText);
+    const role = filterRole(lookupRoleName(message.guild, roleName));
+
+    if (!role) {
+        sendMessage(message.channel, 'Error: role not found');
+    } else if (privilegedRoles.includes(role)) {
+        sendMessage(message.channel, `Error: cannot ${mode} privileged role`);
+    } else {
+        changeRole(member, role, mode);
+        sendRoleConfirmation(message.channel, role.name, member.user.username, mode === 'add' ? 'added' : 'removed');
+    }
+}
+
+module.exports =  {
+    changeRoleCommand,
+    giveRoleCommand
+};

--- a/lib/commands/changeRole.js
+++ b/lib/commands/changeRole.js
@@ -48,7 +48,7 @@ function giveRoleCommand(message, mode) {
     }
 }
 
-module.exports =  {
+module.exports = {
     changeRoleCommand,
-    giveRoleCommand
+    giveRoleCommand,
 };

--- a/lib/commands/changeRole.js
+++ b/lib/commands/changeRole.js
@@ -3,7 +3,7 @@
 
 const source = require('rfr');
 
-const { filterRole, lookupRoleName, splitStringBySpace, discardCommand} = source('lib/commands/commandUtilities');
+const { filterRole, lookupRoleName, discardCommand } = source('lib/commands/commandUtilities');
 const { sendMessage } = source('lib/utils/util');
 const { changeRole } = source('lib/roles/roles');
 
@@ -17,7 +17,7 @@ function sendRoleConfirmation(channel, role, user, mode) {
 
 function changeRoleCommand(message, mode) {
     const roleName = discardCommand(message.content);
-    const member =  message.member;
+    const { member } = message;
     const role = filterRole(lookupRoleName(message.guild, roleName));
 
     if (!role) {

--- a/lib/commands/changeRole.js
+++ b/lib/commands/changeRole.js
@@ -3,7 +3,7 @@
 
 const source = require('rfr');
 
-const { filterRole, getMember, getRole, splitStringBySpace } = source('lib/commands/commandUtilities');
+const { filterRole, lookupRoleName, splitStringBySpace, discardCommand} = source('lib/commands/commandUtilities');
 const { sendMessage } = source('lib/utils/util');
 const { changeRole } = source('lib/roles/roles');
 
@@ -16,14 +16,12 @@ function sendRoleConfirmation(channel, role, user, mode) {
 }
 
 function changeRoleCommand(message, mode) {
-    const parts = splitStringBySpace(message.content);
-    const member = parts.length === 3 ? getMember(message.guild, parts[1]) : message.member;
-    const role = filterRole(getRole(message.guild, parts.length === 3 ? parts[2] : parts[1]));
+    const roleName = discardCommand(message.content);
+    const member =  message.member;
+    const role = filterRole(lookupRoleName(message.guild, roleName));
 
     if (!role) {
         sendMessage(message.channel, 'Error: role not found');
-    } else if (!member) {
-        sendMessage(message.channel, 'Error: member not found');
     } else if (privilegedRoles.includes(role)) {
         sendMessage(message.channel, `Error: cannot ${mode} privileged role`);
     } else {

--- a/lib/commands/commandUtilities.js
+++ b/lib/commands/commandUtilities.js
@@ -27,6 +27,10 @@ function getRole(guild, string) {
     return guild.roles.cache.get(str1Id);
 }
 
+function lookupRoleName(guild, string) {
+    return guild.roles.cache.find(role => role.name === string);;
+}
+
 // Roles Discord Bot does not have access to
 function filterRole(role) {
     if (!role || role.name === 'admin') {
@@ -47,4 +51,5 @@ module.exports = {
     getRole,
     filterRole,
     discardCommand,
+    lookupRoleName,
 };

--- a/lib/commands/commandUtilities.js
+++ b/lib/commands/commandUtilities.js
@@ -51,5 +51,6 @@ module.exports = {
     getRole,
     filterRole,
     discardCommand,
+    discardFirst: discardCommand,
     lookupRoleName,
 };

--- a/lib/commands/commandUtilities.js
+++ b/lib/commands/commandUtilities.js
@@ -28,7 +28,7 @@ function getRole(guild, string) {
 }
 
 function lookupRoleName(guild, string) {
-    return guild.roles.cache.find(role => role.name === string);;
+    return guild.roles.cache.find((role) => role.name === string);
 }
 
 // Roles Discord Bot does not have access to

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -16,20 +16,12 @@ const exampleEmbed = {
             value: 'checks if the bot is active',
         },
         {
-            name: 'role @role',
-            value: 'assigns @role to caller',
+            name: 'role role',
+            value: 'assigns role to caller',
         },
         {
-            name: 'role @user @role',
-            value: 'assigns @role to @user',
-        },
-        {
-            name: 'remove @role',
-            value: 'removes @role from caller',
-        },
-        {
-            name: 'remove @user @role',
-            value: 'assigns @role to @user',
+            name: 'remove role',
+            value: 'removes role from caller',
         },
         {
             name: 'meme',

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -16,12 +16,20 @@ const exampleEmbed = {
             value: 'checks if the bot is active',
         },
         {
-            name: 'role role',
+            name: 'role name-of-role',
             value: 'assigns role to caller',
         },
         {
-            name: 'remove role',
+            name: 'remove name-of-role',
             value: 'removes role from caller',
+        },
+        {
+            name: 'give @user name-of-role',
+            value: 'assigns role to user',
+        },
+        {
+            name: 'revoke @user name-of-role',
+            value: 'removes role from user',
         },
         {
             name: 'meme',


### PR DESCRIPTION
Closes #7. 

This should allow a user to add / remove a role from themselves without needing to `@role` by sending the command `!role role Name`. Note that this also removed the ability to give or remove a role from another user. 

Also added a `!give @user role-name` and a `!revoke @user role-name` to grant and remove roles from other users. 