### PR TITLE
54 allow disabling commands

### DIFF
--- a/lib/commands/admin/disableCommand.js
+++ b/lib/commands/admin/disableCommand.js
@@ -3,7 +3,7 @@ const source = require('rfr');
 const { sendMessage } = source('lib/utils/util');
 const { Settings } = source('lib/database/models/settings');
 
-function addMemeSubCommand(message, args) {
+function disableCommand(message, args) {
     const commandName = args[0].toLowerCase();
 
     const { commands } = message.client;
@@ -29,5 +29,5 @@ module.exports = {
     description: 'disables a command on this server',
     usage: '<command>',
     aliases: [],
-    execute: addMemeSubCommand,
+    execute: disableCommand,
 };

--- a/lib/commands/admin/disableCommand.js
+++ b/lib/commands/admin/disableCommand.js
@@ -1,0 +1,27 @@
+const source = require('rfr');
+
+const { sendMessage } = source('lib/utils/util');
+const { Settings } = source('lib/database/models/settings');
+
+function addMemeSubCommand(message, args) {
+    const command = args[0].toLowerCase();
+
+    if (command === 'enable-command' || command === 'disable-command') {
+        return sendMessage(message.channel, `The command \`${command}\` can not be disabled.`);
+    }
+
+    return Settings.getServerSettings(message.guild.id)
+        .then((config) => config.disableCommand(command).save())
+        .then(() => sendMessage(message.channel, 'Settings updated.'))
+        .catch((err) => sendMessage(message.channel, `Error Something went wrong: ${err.message}`));
+}
+
+module.exports = {
+    args: 1,
+    name: 'disable-command',
+    botAdmin: true,
+    description: 'disables a command on this server',
+    usage: '<command>',
+    aliases: [],
+    execute: addMemeSubCommand,
+};

--- a/lib/commands/admin/disableCommand.js
+++ b/lib/commands/admin/disableCommand.js
@@ -4,14 +4,19 @@ const { sendMessage } = source('lib/utils/util');
 const { Settings } = source('lib/database/models/settings');
 
 function addMemeSubCommand(message, args) {
-    const command = args[0].toLowerCase();
+    const commandName = args[0].toLowerCase();
 
-    if (command === 'enable-command' || command === 'disable-command') {
-        return sendMessage(message.channel, `The command \`${command}\` can not be disabled.`);
-    }
+    const { commands } = message.client;
+
+    const command = commands.get(commandName)
+                    || commands.find((c) => c.aliases && c.aliases.includes(commandName));
+
+    if (!command) return sendMessage(message.channel, `The command \`${commandName}\` does not exist.`);
+
+    if (command.alwaysEnabled) return sendMessage(message.channel, `The command \`${commandName}\` cannot be disabled.`);
 
     return Settings.getServerSettings(message.guild.id)
-        .then((config) => config.disableCommand(command).save())
+        .then((config) => config.disableCommand(command.name).save())
         .then(() => sendMessage(message.channel, 'Settings updated.'))
         .catch((err) => sendMessage(message.channel, `Error Something went wrong: ${err.message}`));
 }
@@ -20,6 +25,7 @@ module.exports = {
     args: 1,
     name: 'disable-command',
     botAdmin: true,
+    alwaysEnabled: true,
     description: 'disables a command on this server',
     usage: '<command>',
     aliases: [],

--- a/lib/commands/admin/enableCommand.js
+++ b/lib/commands/admin/enableCommand.js
@@ -1,0 +1,27 @@
+const source = require('rfr');
+
+const { sendMessage } = source('lib/utils/util');
+const { Settings } = source('lib/database/models/settings');
+
+function addMemeSubCommand(message, args) {
+    const command = args[0].toLowerCase();
+
+    if (command === 'enable-command' || command === 'disable-command') {
+        return sendMessage(message.channel, `The command \`${command}\` can not be enabled.`);
+    }
+
+    return Settings.getServerSettings(message.guild.id)
+        .then((config) => config.enableCommand(command).save())
+        .then(() => sendMessage(message.channel, 'Settings updated.'))
+        .catch((err) => sendMessage(message.channel, `Error Something went wrong: ${err.message}`));
+}
+
+module.exports = {
+    args: 1,
+    name: 'enable-command',
+    botAdmin: true,
+    description: 'enables a command that has previously been disabled on this server',
+    usage: '<command>',
+    aliases: [],
+    execute: addMemeSubCommand,
+};

--- a/lib/commands/admin/enableCommand.js
+++ b/lib/commands/admin/enableCommand.js
@@ -3,7 +3,7 @@ const source = require('rfr');
 const { sendMessage } = source('lib/utils/util');
 const { Settings } = source('lib/database/models/settings');
 
-function addMemeSubCommand(message, args) {
+function enableCommand(message, args) {
     const commandName = args[0].toLowerCase();
 
     const { commands } = message.client;
@@ -29,5 +29,5 @@ module.exports = {
     description: 'enables a command that has previously been disabled on this server',
     usage: '<command>',
     aliases: [],
-    execute: addMemeSubCommand,
+    execute: enableCommand,
 };

--- a/lib/commands/admin/enableCommand.js
+++ b/lib/commands/admin/enableCommand.js
@@ -4,14 +4,19 @@ const { sendMessage } = source('lib/utils/util');
 const { Settings } = source('lib/database/models/settings');
 
 function addMemeSubCommand(message, args) {
-    const command = args[0].toLowerCase();
+    const commandName = args[0].toLowerCase();
 
-    if (command === 'enable-command' || command === 'disable-command') {
-        return sendMessage(message.channel, `The command \`${command}\` can not be enabled.`);
-    }
+    const { commands } = message.client;
+
+    const command = commands.get(commandName)
+                    || commands.find((c) => c.aliases && c.aliases.includes(commandName));
+
+    if (!command) return sendMessage(message.channel, `The command \`${commandName}\` does not exist.`);
+
+    if (command.alwaysEnabled) return sendMessage(message.channel, `The command \`${commandName}\` cannot be disabled.`);
 
     return Settings.getServerSettings(message.guild.id)
-        .then((config) => config.enableCommand(command).save())
+        .then((config) => config.enableCommand(command.name).save())
         .then(() => sendMessage(message.channel, 'Settings updated.'))
         .catch((err) => sendMessage(message.channel, `Error Something went wrong: ${err.message}`));
 }
@@ -20,6 +25,7 @@ module.exports = {
     args: 1,
     name: 'enable-command',
     botAdmin: true,
+    alwaysEnabled: true,
     description: 'enables a command that has previously been disabled on this server',
     usage: '<command>',
     aliases: [],

--- a/lib/commands/information/help.js
+++ b/lib/commands/information/help.js
@@ -2,6 +2,7 @@ const source = require('rfr');
 
 const { sendMessage } = source('lib/utils/util');
 const { Settings } = source('lib/database/models/settings');
+const { findRole } = source('lib/roles/roles');
 
 const logger = source('lib/utils/logger');
 
@@ -17,50 +18,80 @@ const helpEmbeded = {
     },
 };
 
+function helpGeneral(message, commands, config) {
+    const fields = commands.map((command) => {
+        // check if the command should should be shown in the help list
+        if (config.disabledCommands.includes(command.name)) return null;
+        if (command.botAdmin && !findRole(message.member, config.botAdminRole)) return null;
+
+        return {
+            name: command.name + (command.botAdmin ? ' - bot admin only' : ''),
+            value: command.description,
+        };
+    }).filter((f) => f !== null);
+
+    helpEmbeded.fields = fields;
+    return sendMessage(message.channel, {
+        embed: helpEmbeded,
+    });
+}
+
+function helpSpecific(message, command, config) {
+    // check if the command is disabled
+    if (config.disabledCommands.includes(command.name)) {
+        return sendMessage(message.channel, `${command.name} is not allowed on this server, `
+                + 'contact one of the server admins if you think this is a mistake!');
+    }
+
+    // dont provide help if the user is not authorized for that command
+    if (command.botAdmin && !findRole(message.member, config.botAdminRole)) {
+        return sendMessage(message.channel, `You are not authorized to use the ${command.name} command`);
+    }
+
+    const fields = [
+        {
+            name: 'Name', value: command.name,
+        }, {
+            name: 'Bot Admin Only', value: command.botAdmin ? 'yes' : 'no',
+        },
+    ];
+
+    if (command.aliases && command.aliases.length > 0) {
+        fields.push({
+            name: 'Aliases', value: command.aliases.join(', '),
+        });
+    }
+    if (command.description) {
+        fields.push({
+            name: 'Description', value: command.description,
+        });
+    }
+    if (command.usage) {
+        fields.push({
+            name: 'Usage', value: `${config.commandPrefix}${command.name} ${command.usage}`,
+        });
+    }
+
+    helpEmbeded.fields = fields;
+    return sendMessage(message.channel, {
+        embed: helpEmbeded,
+    });
+}
+
 function helpCommand(message, args) {
     const { commands } = message.client;
 
     Settings.getServerSettings(message.guild.id)
         .then((config) => {
-            let fields = [];
             if (args.length === 0) {
-                fields = commands.map((command) => ({
-                    name: command.name + (command.botAdmin ? ' - bot admin only' : ''),
-                    value: command.description,
-                }));
-            } else {
-                const command = commands.get(args[0].toLowerCase());
-                if (!command) return sendMessage(message.channel, `${args[0]} is not a valid command!`);
-
-                fields.push({
-                    name: 'Name', value: command.name,
-                });
-                fields.push({
-                    name: 'Bot Admin Only', value: command.botAdmin ? 'yes' : 'no',
-                });
-
-                if (command.aliases && command.aliases.length > 0) {
-                    fields.push({
-                        name: 'Aliases', value: command.aliases.join(', '),
-                    });
-                }
-                if (command.description) {
-                    fields.push({
-                        name: 'Description', value: command.description,
-                    });
-                }
-                if (command.usage) {
-                    fields.push({
-                        name: 'Usage', value: `${config.commandPrefix}${command.name} ${command.usage}`,
-                    });
-                }
+                return helpGeneral(message, commands, config);
             }
+            const name = args[0].toLowerCase();
+            const command = commands.get(name)
+            || commands.find((c) => c.aliases && c.aliases.includes(name));
 
-            helpEmbeded.fields = fields;
-
-            return sendMessage(message.channel, {
-                embed: helpEmbeded,
-            });
+            if (!command) return sendMessage(message.channel, `${name} is not a valid command!`);
+            return helpSpecific(message, command, config);
         })
         .catch((err) => logger.error('Something went wrong loading the server settings:', err));
 }

--- a/lib/commands/information/help.js
+++ b/lib/commands/information/help.js
@@ -100,6 +100,7 @@ module.exports = {
     args: false,
     name: 'help',
     botAdmin: false,
+    alwaysEnabled: true,
     description: 'lists all the commands or info about a specific command',
     usage: '[command name]',
     aliases: ['commands'],

--- a/lib/database/models/settings/schema.js
+++ b/lib/database/models/settings/schema.js
@@ -96,4 +96,7 @@ module.exports = new mongoose.Schema({
         type: [String],
         default: cuteSubreddits,
     },
+    disabled_commands: {
+        type: [String],
+    },
 });

--- a/lib/database/models/settings/settings.js
+++ b/lib/database/models/settings/settings.js
@@ -62,6 +62,10 @@ class Settings {
         return this._model.bot_admin_role;
     }
 
+    get disabledCommands() {
+        return this._model.disabled_commands;
+    }
+
     setGuild(guild) {
         if (typeof guild === 'string') {
             this._model.guild = guild;
@@ -142,6 +146,22 @@ class Settings {
     addCuteSub(sub) {
         if (typeof sub === 'string') {
             this._model.cute_subreddits.push(sub);
+        }
+        return this;
+    }
+
+    disableCommand(command) {
+        if (typeof command === 'string') {
+            this._model.disabled_commands.push(command);
+        }
+        return this;
+    }
+
+    enableCommand(command) {
+        if (typeof command === 'string') {
+            const index = this._model.disabled_commands.indexOf(command);
+
+            if (index > -1) this._model.disabled_commands.splice(index, 1);
         }
         return this;
     }

--- a/lib/scanner/commandHandler.js
+++ b/lib/scanner/commandHandler.js
@@ -18,10 +18,6 @@ function setupCommands(client) {
         commandFiles.forEach((file) => {
             const command = source(`lib/commands/${folder}/${file}`);
             client.commands.set(command.name, command);
-
-            if (command.aliases) {
-                command.aliases.forEach((alias) => client.commands.set(alias, command));
-            }
         });
     });
 }
@@ -36,9 +32,16 @@ function commandHandler(message) {
 
             const args = message.content.slice(prefix.length).trim().split(/ +/);
             const commandName = args.shift().toLowerCase();
-            const command = commands.get(commandName);
+            const command = commands.get(commandName)
+                            || commands.find((c) => c.aliases && c.aliases.includes(commandName));
 
             if (!command) throw new Error(`command ${commandName} does not exist.`);
+
+            if (config.disabledCommands.includes(command.name)) {
+                sendMessage(message.channel, `${commandName} is not allowed on this server, `
+                            + 'contact one of the server admins if you think this is a mistake.');
+                return;
+            }
 
             if (command.args && args.length < command.args) {
                 let reply = `You didn't provide enough arguments, ${message.author}!`;


### PR DESCRIPTION
Closes #54 

Commands can now be enabled or disabled. 

Currently the following commands are marked as always enabled and can not be dissabled:
- `enable-command`
- `disable-command`
- `help`