### PR TITLE
Remove redundant server settings lookup

### DIFF
--- a/lib/commands/admin/addCuteSubreddit.js
+++ b/lib/commands/admin/addCuteSubreddit.js
@@ -1,11 +1,9 @@
 const source = require('rfr');
 
 const { sendMessage } = source('lib/utils/util');
-const { Settings } = source('lib/database/models/settings');
 
-function addCuteSubCommand(message, args) {
-    return Settings.getServerSettings(message.guild.id)
-        .then((config) => config.addCuteSub(args[0]).save())
+function addCuteSubCommand(message, args, config) {
+    return config.addCuteSub(args[0]).save()
         .then(() => sendMessage(message.channel, 'Settings updated.'))
         .catch((err) => sendMessage(message.channel, 'Error Something went wrong:', err));
 }

--- a/lib/commands/admin/addMemeSubreddit.js
+++ b/lib/commands/admin/addMemeSubreddit.js
@@ -1,11 +1,9 @@
 const source = require('rfr');
 
 const { sendMessage } = source('lib/utils/util');
-const { Settings } = source('lib/database/models/settings');
 
-function addMemeSubCommand(message, args) {
-    return Settings.getServerSettings(message.guild.id)
-        .then((config) => config.addMemeSub(args[0]).save())
+function addMemeSubCommand(message, args, config) {
+    return config.addMemeSub(args[0]).save()
         .then(() => sendMessage(message.channel, 'Settings updated.'))
         .catch((err) => sendMessage(message.channel, 'Error Something went wrong:', err));
 }

--- a/lib/commands/admin/disableCommand.js
+++ b/lib/commands/admin/disableCommand.js
@@ -1,9 +1,8 @@
 const source = require('rfr');
 
 const { sendMessage } = source('lib/utils/util');
-const { Settings } = source('lib/database/models/settings');
 
-function disableCommand(message, args) {
+function disableCommand(message, args, config) {
     const commandName = args[0].toLowerCase();
 
     const { commands } = message.client;
@@ -15,8 +14,7 @@ function disableCommand(message, args) {
 
     if (command.alwaysEnabled) return sendMessage(message.channel, `The command \`${commandName}\` cannot be disabled.`);
 
-    return Settings.getServerSettings(message.guild.id)
-        .then((config) => config.disableCommand(command.name).save())
+    return config.disableCommand(command.name).save()
         .then(() => sendMessage(message.channel, 'Settings updated.'))
         .catch((err) => sendMessage(message.channel, `Error Something went wrong: ${err.message}`));
 }

--- a/lib/commands/admin/enableCommand.js
+++ b/lib/commands/admin/enableCommand.js
@@ -1,9 +1,8 @@
 const source = require('rfr');
 
 const { sendMessage } = source('lib/utils/util');
-const { Settings } = source('lib/database/models/settings');
 
-function enableCommand(message, args) {
+function enableCommand(message, args, config) {
     const commandName = args[0].toLowerCase();
 
     const { commands } = message.client;
@@ -15,8 +14,7 @@ function enableCommand(message, args) {
 
     if (command.alwaysEnabled) return sendMessage(message.channel, `The command \`${commandName}\` cannot be disabled.`);
 
-    return Settings.getServerSettings(message.guild.id)
-        .then((config) => config.enableCommand(command.name).save())
+    return config.enableCommand(command.name).save()
         .then(() => sendMessage(message.channel, 'Settings updated.'))
         .catch((err) => sendMessage(message.channel, `Error Something went wrong: ${err.message}`));
 }

--- a/lib/commands/admin/setMusicChannel.js
+++ b/lib/commands/admin/setMusicChannel.js
@@ -1,14 +1,12 @@
 const source = require('rfr');
 
 const { sendMessage, getChannel } = source('lib/utils/util');
-const { Settings } = source('lib/database/models/settings');
 
-function setMusicCHannel(message, args) {
+function setMusicCHannel(message, args, config) {
     const channel = getChannel(message.guild, args[0]);
     if (!channel) return sendMessage(message.channel, `${args[0]} is not a valid channel`);
 
-    return Settings.getServerSettings(message.guild.id)
-        .then((config) => config.setMusicChannel(channel.id).save())
+    return config.setMusicChannel(channel.id).save()
         .then(() => sendMessage(message.channel, 'Settings updated.'))
         .catch((err) => sendMessage(message.channel, 'Error Something went wrong:', err));
 }

--- a/lib/commands/admin/setPlaylistDescription.js
+++ b/lib/commands/admin/setPlaylistDescription.js
@@ -1,11 +1,9 @@
 const source = require('rfr');
 
 const { sendMessage } = source('lib/utils/util');
-const { Settings } = source('lib/database/models/settings');
 
-function setPlaylistDescriptionCommand(message, args) {
-    return Settings.getServerSettings(message.guild.id)
-        .then((config) => config.setPlaylistDescription(args.join(' ')).save())
+function setPlaylistDescriptionCommand(message, args, config) {
+    return config.setPlaylistDescription(args.join(' ')).save()
         .then(() => sendMessage(message.channel, 'Settings updated.'))
         .catch((err) => sendMessage(message.channel, 'Error Something went wrong:', err));
 }

--- a/lib/commands/admin/setPlaylistName.js
+++ b/lib/commands/admin/setPlaylistName.js
@@ -1,11 +1,9 @@
 const source = require('rfr');
 
 const { sendMessage } = source('lib/utils/util');
-const { Settings } = source('lib/database/models/settings');
 
-function setPlaylistNameCommand(message, args) {
-    return Settings.getServerSettings(message.guild.id)
-        .then((config) => config.setPlaylistName(args.join(' ')).save())
+function setPlaylistNameCommand(message, args, config) {
+    return config.setPlaylistName(args.join(' ')).save()
         .then(() => sendMessage(message.channel, 'Settings updated.'))
         .catch((err) => sendMessage(message.channel, 'Error Something went wrong:', err));
 }

--- a/lib/commands/admin/setPrefixCommand.js
+++ b/lib/commands/admin/setPrefixCommand.js
@@ -1,11 +1,9 @@
 const source = require('rfr');
 
 const { sendMessage } = source('lib/utils/util');
-const { Settings } = source('lib/database/models/settings');
 
-function setPrefixCommand(message, args) {
-    return Settings.getServerSettings(message.guild.id)
-        .then((config) => config.setCommandPrefix(args[0]).save())
+function setPrefixCommand(message, args, config) {
+    return config.setCommandPrefix(args[0]).save()
         .then(() => sendMessage(message.channel, 'Settings updated.'))
         .catch((err) => sendMessage(message.channel, 'Error Something went wrong:', err));
 }

--- a/lib/commands/admin/setRoleMappingCommand.js
+++ b/lib/commands/admin/setRoleMappingCommand.js
@@ -4,18 +4,16 @@
 const source = require('rfr');
 
 const { sendMessage, getChannel } = source('lib/utils/util');
-const { Settings } = source('lib/database/models/settings');
 const logger = source('lib/utils/logger');
 
-function setRoleChannelCommand(message, args) {
+function setRoleChannelCommand(message, args, config) {
     const channel = getChannel(message.guild, args[0]);
 
     if (channel === undefined) return sendMessage(message.channel, `${args[0]} is not a valid channel to post to`);
 
     logger.info('updating the server to send the reaction messages to channel:', channel);
 
-    return Settings.getServerSettings(message.guild.id)
-        .then((config) => config.setWelcomeChannel(channel.id).save())
+    return config.setWelcomeChannel(channel.id).save()
         .then(() => sendMessage(message.channel, 'Settings updated.'))
         .catch((err) => sendMessage(message.channel, `Error Something went wrong: ${err}`));
 }

--- a/lib/commands/admin/setRoles.js
+++ b/lib/commands/admin/setRoles.js
@@ -2,30 +2,28 @@ const source = require('rfr');
 const emojiRegex = require('emoji-regex/RGI_Emoji.js');
 
 const { sendMessage } = source('lib/utils/util');
-const { Settings } = source('lib/database/models/settings');
 const { Role } = source('lib/database/models/role');
 
 const { parseRoleMessage } = source('lib/utils/roleParsing');
 const logger = source('lib/utils/logger');
 
-function postRoleReactions(guild, header, mappings) {
-    let settings;
+function postRoleReactions(guild, header, mappings, config) {
     let watchMessage;
-    return Settings.getServerSettings(guild.id)
-        .then((config) => {
-            settings = config;
-            const welcomeChannel = guild.channels.cache.get(config.welcomeChannel);
 
-            if (welcomeChannel === undefined) {
-                throw new Error(`need to set the channel to post the role message too, use the \`${config.commandPrefix}set-role-channel\` command`);
-            }
+    const content = mappings.reduce((acc, m) => `${acc}${m.reactionEmoji} : \`${m.mapping.label}\`\n`, `${header}\n\n`);
 
-            const content = mappings.reduce((acc, m) => `${acc}${m.reactionEmoji} : \`${m.mapping.label}\`\n`, `${header}\n\n`);
-            return sendMessage(welcomeChannel, content);
-        })
+    return new Promise(((resolve, reject) => {
+        const welcomeChannel = guild.channels.cache.get(config.welcomeChannel);
+
+        if (welcomeChannel === undefined) {
+            return reject(new Error(`need to set the channel to post the role message too, use the \`${config.commandPrefix}set-role-channel\` command`));
+        }
+        return resolve(welcomeChannel);
+    }))
+        .then((welcomeChannel) => sendMessage(welcomeChannel, content))
         .then((message) => {
             watchMessage = message;
-            return settings.setRoleMessage(message.id).save();
+            return config.setRoleMessage(message.id).save();
         })
         .then(() => watchMessage);
 }
@@ -34,7 +32,7 @@ function reactToMessage(message, mappings) {
     return Promise.all(mappings.map((m) => message.react(m.reactionEmoji)));
 }
 
-function setRoleMessageCommand(message, args) {
+function setRoleMessageCommand(message, args, config) {
     const parts = parseRoleMessage(args.join(' '));
 
     // lookup the actual emoji to use react with
@@ -50,7 +48,7 @@ function setRoleMessageCommand(message, args) {
         };
     });
 
-    return postRoleReactions(message.guild, parts.header, mappings)
+    return postRoleReactions(message.guild, parts.header, mappings, config)
         .then((m) => reactToMessage(m, mappings))
         .then(() => Role.removeServerRoles(message.guild.id))
         .then(() => {

--- a/lib/commands/information/help.js
+++ b/lib/commands/information/help.js
@@ -1,10 +1,7 @@
 const source = require('rfr');
 
 const { sendMessage } = source('lib/utils/util');
-const { Settings } = source('lib/database/models/settings');
 const { findRole } = source('lib/roles/roles');
-
-const logger = source('lib/utils/logger');
 
 const helpEmbeded = {
     color: 0x0099ff,
@@ -78,22 +75,19 @@ function helpSpecific(message, command, config) {
     });
 }
 
-function helpCommand(message, args) {
+function helpCommand(message, args, config) {
     const { commands } = message.client;
 
-    Settings.getServerSettings(message.guild.id)
-        .then((config) => {
-            if (args.length === 0) {
-                return helpGeneral(message, commands, config);
-            }
-            const name = args[0].toLowerCase();
-            const command = commands.get(name)
-            || commands.find((c) => c.aliases && c.aliases.includes(name));
+    if (args.length === 0) {
+        return helpGeneral(message, commands, config);
+    }
+    const name = args[0].toLowerCase();
+    const command = commands.get(name)
+    || commands.find((c) => c.aliases && c.aliases.includes(name));
 
-            if (!command) return sendMessage(message.channel, `${name} is not a valid command!`);
-            return helpSpecific(message, command, config);
-        })
-        .catch((err) => logger.error('Something went wrong loading the server settings:', err));
+    if (!command) return sendMessage(message.channel, `${name} is not a valid command!`);
+
+    return helpSpecific(message, command, config);
 }
 
 module.exports = {

--- a/lib/commands/information/weather.js
+++ b/lib/commands/information/weather.js
@@ -2,7 +2,6 @@ const source = require('rfr');
 const weather = require('weather-promise');
 
 const { sendMessage } = source('lib/utils/util');
-const { Settings } = source('lib/database/models/settings');
 
 const logger = source('lib/utils/logger');
 
@@ -66,14 +65,13 @@ function sendWeather(message, result) {
     sendMessage(message.channel, payload);
 }
 
-function weatherCommand(message, args) {
+function weatherCommand(message, args, config) {
     const city = args.length > 1 ? `${args[0]}, ON` : undefined;
 
-    Settings.getServerSettings(message.guild.id)
-        .then((config) => weather.find({
-            search: city || config.weatherLocation,
-            degreeType: config.tempUnit,
-        }))
+    return weather.find({
+        search: city || config.weatherLocation,
+        degreeType: config.tempUnit,
+    })
         .then((result) => sendWeather(message, result))
         .catch((err) => logger.error(err));
 }

--- a/lib/commands/music/createPlaylist.js
+++ b/lib/commands/music/createPlaylist.js
@@ -5,7 +5,6 @@ const { createPlaylist, addTracksToPlaylist } = source('lib/spotify/spotifyApi')
 
 const { sendMessage } = source('lib/utils/util');
 const { Song } = source('lib/database/models/song');
-const { Settings } = source('lib/database/models/settings');
 const { Statistics, EventTypes } = source('lib/database/models/statistics');
 
 const logger = source('lib/utils/logger');
@@ -30,30 +29,29 @@ function generateMessage(tracks, playlistId) {
             of them were added by ${counts[0][0]}\nPlaylist: https://open.spotify.com/playlist/${playlistId}`;
 }
 
-function loadPlaylist(message, tracks) {
+function loadPlaylist(message, tracks, config) {
     const user = message.author.id;
     const { channel } = message;
 
     if (tracks.length === 0) return sendMessage(channel, 'Can not create playlist with no tracks.');
 
-    return Settings.getServerSettings(message.guild.id)
-        .then((config) => createPlaylist(user, config.playlistName, config.playlistDescription))
+    return createPlaylist(user, config.playlistName, config.playlistDescription)
         .then((playlistId) => addTracksToPlaylist(user, playlistId, tracks.map((t) => t.trackURI)))
         .then((playlistId) => sendMessage(channel, generateMessage(tracks, playlistId)));
 }
 
-function findTracks(message, timestamp) {
+function findTracks(message, timestamp, config) {
     return Song.findSince(message.guild.id, timestamp)
-        .then((tracks) => loadPlaylist(message, tracks))
+        .then((tracks) => loadPlaylist(message, tracks, config))
         .catch((err) => logger.error('Something went wrong, failed to create and add tracks to the playlist.', err));
 }
 
-function generatePlaylistCommand(message, args) {
+function generatePlaylistCommand(message, args, config) {
     const timeOffset = parse(args.join(' ')) || 604800000; // default of 1 week
     const timestamp = new Date();
     timestamp.setTime(timestamp.valueOf() - timeOffset);
 
-    findTracks(message, timestamp)
+    findTracks(message, timestamp, config)
         .then(() => new Statistics()
             .setGuild(message.guild.id)
             .setEvent(EventTypes.PLAYLIST_CREATED)

--- a/lib/commands/reddit/cute.js
+++ b/lib/commands/reddit/cute.js
@@ -2,13 +2,11 @@ const source = require('rfr');
 const _ = require('lodash');
 
 const { redditPost } = source('lib/utils/reddit');
-const { Settings } = source('lib/database/models/settings');
 
 const logger = source('lib/utils/logger');
 
-function cuteCommand(message) {
-    Settings.getServerSettings(message.guild.id)
-        .then((config) => redditPost(message, _.sample(config.cuteSubs)))
+function cuteCommand(message, args, config) {
+    return redditPost(message, _.sample(config.cuteSubs))
         .catch((err) => logger.error('error getting settings:', err));
 }
 

--- a/lib/commands/reddit/meme.js
+++ b/lib/commands/reddit/meme.js
@@ -2,14 +2,12 @@ const source = require('rfr');
 const _ = require('lodash');
 
 const { redditPost } = source('lib/utils/reddit');
-const { Settings } = source('lib/database/models/settings');
 const { Statistics, EventTypes } = source('lib/database/models/statistics');
 
 const logger = source('lib/utils/logger');
 
-function memeCommand(message) {
-    Settings.getServerSettings(message.guild.id)
-        .then((config) => redditPost(message, _.sample(config.memeSubs)))
+function memeCommand(message, args, config) {
+    return redditPost(message, _.sample(config.memeSubs))
         .then(() => new Statistics()
             .setGuild(message.guild.id)
             .setEvent(EventTypes.MEMES_SENT)

--- a/lib/scanner/commandHandler.js
+++ b/lib/scanner/commandHandler.js
@@ -63,7 +63,7 @@ function commandHandler(message) {
                 return sendMessage(message.channel, reply);
             }
 
-            command.execute(message, args);
+            command.execute(message, args, config);
             return new Statistics()
                 .setGuild(message.guild.id)
                 .setEvent(EventTypes.COMMAND_EXECUTED)


### PR DESCRIPTION
Closes: #82 

Changed all the commands that use the server settings object to take the config as a parameter so that each command does not have to look up the server settings again.

Checklist:

- [ ] Add automated tests cases
- [x] Run `npm run lint-fix` and ensure linter is still passing
- [x] Verify that all automated tests pass
- [x] Verify that the changes work as expected on Discord
- [ ] Update the README and other applicable documentation pages
- [ ] Update the changelog
