### PR TITLE
Display the actual stats to display on the stats page

### DIFF
--- a/lib/database/models/message/message.js
+++ b/lib/database/models/message/message.js
@@ -76,6 +76,15 @@ class Message {
     save() {
         return this._model.save().then(() => this);
     }
+
+    static count() {
+        return MessageModel
+            .count()
+            .then((count) => ({
+                database: Message.name,
+                count,
+            }));
+    }
 }
 
 module.exports = {

--- a/lib/database/models/role/role.js
+++ b/lib/database/models/role/role.js
@@ -68,6 +68,15 @@ class Role {
             guild: serverID,
         });
     }
+
+    static count() {
+        return RoleModel
+            .count()
+            .then((count) => ({
+                database: Role.name,
+                count,
+            }));
+    }
 }
 
 module.exports = {

--- a/lib/database/models/song/song.js
+++ b/lib/database/models/song/song.js
@@ -89,6 +89,15 @@ class Song {
                 return s;
             }));
     }
+
+    static count() {
+        return SongModel
+            .count()
+            .then((count) => ({
+                database: Song.name,
+                count,
+            }));
+    }
 }
 
 module.exports = {

--- a/lib/database/models/statistics/statistics.js
+++ b/lib/database/models/statistics/statistics.js
@@ -64,10 +64,21 @@ class Statistics {
                 event: eventName,
             })
             .count()
-            .then((results) => results.map((r) => {
-                const s = new Statistics();
-                s._model = r;
-                return s;
+            .then((count) => ({
+                event: eventName,
+                count,
+            }));
+    }
+
+    static totalEvents(eventName) {
+        return StatsModel
+            .where({
+                event: eventName,
+            })
+            .count()
+            .then((count) => ({
+                event: eventName,
+                count,
             }));
     }
 }

--- a/routes/controllers/statisticsController.js
+++ b/routes/controllers/statisticsController.js
@@ -1,26 +1,40 @@
+const source = require('rfr');
+
+const Bot = source('lib/bot');
+
+const { Statistics, EventTypes } = source('lib/database/models/statistics');
+const { Message } = source('lib/database/models/message');
+const { Role } = source('lib/database/models/role');
+const { Song } = source('lib/database/models/song');
+
+const logger = source('lib/utils/logger');
+
 const StatisticsController = {
     get(req, res) {
-        const servers = 10;
-        const numCommands = 15;
-        const commands = 500;
-        const messages = 10000;
-        const numRoles = 25;
-        const roles = 100;
-        const songs = 250;
-        const goodBot = 50;
-        const badBot = 50;
-
-        res.render('statistics', {
-            servers,
-            numCommands,
-            commands,
-            messages,
-            numRoles,
-            roles,
-            songs,
-            goodBot,
-            badBot,
-        });
+        Promise.all([
+            Statistics.totalEvents(EventTypes.COMMAND_EXECUTED), // 0
+            Statistics.totalEvents(EventTypes.GOOD_BOT), // 1
+            Statistics.totalEvents(EventTypes.BAD_BOT), // 2
+            Statistics.totalEvents(EventTypes.PLAYLIST_CREATED), // 3
+            Statistics.totalEvents(EventTypes.ROLE_ASSIGNED), // 4
+            Message.count(), // 5
+            Role.count(), // 6
+            Song.count(), // 7
+        ]).then((values) => {
+            res.render('statistics', {
+                numServer: Bot.client.guilds.cache.size,
+                numCommands: Bot.client.commands.size,
+                commandsRun: values[0].count,
+                messages: values[5].count,
+                numRoles: values[6].count,
+                rolesAssigned: values[4].count,
+                numSongs: values[7].count,
+                numPlaylists: values[3].count,
+                goodBot: values[1].count,
+                badBot: values[2].count,
+            });
+        })
+            .catch((e) => logger.error('failed to generate the statistics page', e));
     },
 };
 

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -39,9 +39,9 @@
 <!--                <div class="navbar-nav">-->
 <!--                    <a class="nav-item nav-link active" href="/documentation">Documentation</a>-->
 <!--                </div>-->
-<!--                <div class="navbar-nav">-->
-<!--                    <a class="nav-item nav-link active" href="/statistics">Statistics</a>-->
-<!--                </div>-->
+                <div class="navbar-nav">
+                    <a class="nav-item nav-link active" href="/statistics">Statistics</a>
+                </div>
             </div>
 
             <ul class="navbar-nav">

--- a/views/statistics.handlebars
+++ b/views/statistics.handlebars
@@ -1,10 +1,10 @@
 <main role="main">
     <div class="container center-content" style="padding: 0">
-        <h1 class="statistics-header-padding">Statistics</h1>
-        <h5>I am a part of {{{ servers }}} servers.</h5>
-        <h5>I know {{{ numCommands }}} commands and have ran over {{{ commands }}} commands.</h5>
-        <h5>My eye is on {{{ numRoles }}} roles and have assigned {{{ roles }}}.</h5>
-        <h5>I have saved {{{ songs }}} songs to Spotify.</h5>
+        <h1 class="statistics-header-padding">All Time Statistics</h1>
+        <h5>I am a part of {{{ numServer }}} servers.</h5>
+        <h5>I know {{{ numCommands }}} commands and have ran over {{{ commandsRun }}} commands.</h5>
+        <h5>My eye is on {{{ numRoles }}} roles and have assigned {{{ rolesAssigned }}}.</h5>
+        <h5>I have saved {{{ numSongs }}} songs to {{{ numPlaylists }}} Spotify playlists.</h5>
         <h5>{{{ messages }}} messages read.</h5>
         <h5>I have been good over {{{ goodBot }}} times! But, on occasion, just {{{ badBot }}} times, I've been bad.</h5>
     </div>


### PR DESCRIPTION
Closes: #60 
Related: #9 

This will display the actual statistics onto the stats page instead of just using place holder values.

Checklist:

- [ ] Add automated tests cases
- [x] Run `npm run lint-fix` and ensure linter is still passing
- [x] Verify that all automated tests pass
- [x] Verify that the changes work as expected on Discord
- [ ] Update the README and other applicable documentation pages
- [ ] Update the changelog
