### PR TITLE
one of the stats fields was incorrectly marked as required

### DIFF
--- a/lib/database/models/statistics/schema.js
+++ b/lib/database/models/statistics/schema.js
@@ -21,6 +21,6 @@ module.exports = new mongoose.Schema({
     },
     details: {
         type: String,
-        required: true,
+        required: false,
     },
 });


### PR DESCRIPTION
one of the stats fields was incorrectly marked as required

Checklist:


- [ ] Add automated tests cases
- [x] Run `npm run lint-fix` and ensure linter is still passing
- [x] Verify that all automated tests pass
- [x] Verify that the changes work as expected on Discord
- [ ] Update the README and other applicable documentation pages
- [ ] Update the changelog
