### PR TITLE
renamed enable and disable command

### DIFF
--- a/bot/commands/admin/disableCommand.js
+++ b/bot/commands/admin/disableCommand.js
@@ -21,11 +21,11 @@ function disableCommand(message, args, config) {
 
 module.exports = {
     args: 1,
-    name: 'disable-command',
+    name: 'disable',
     botAdmin: true,
     alwaysEnabled: true,
     description: 'disables a command on this server',
     usage: '<command>',
-    aliases: [],
+    aliases: ['disable-command'],
     execute: disableCommand,
 };

--- a/bot/commands/admin/enableCommand.js
+++ b/bot/commands/admin/enableCommand.js
@@ -21,11 +21,11 @@ function enableCommand(message, args, config) {
 
 module.exports = {
     args: 1,
-    name: 'enable-command',
+    name: 'enable',
     botAdmin: true,
     alwaysEnabled: true,
     description: 'enables a command that has previously been disabled on this server',
     usage: '<command>',
-    aliases: [],
+    aliases: ['enable-command'],
     execute: enableCommand,
 };


### PR DESCRIPTION
As per one of the conversations I have renamed the enable and disable commands, and removed the `-command` suffix, the suffixed version is still present as an alias.


---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Add automated tests cases
- [x] Run `npm run lint-fix` and ensure linter is still passing
- [x] Verify that all automated tests pass
- [ ] Verify that the changes work as expected on Discord
- [ ] Update the README and other applicable documentation pages
- [ ] Update the changelog
