### PR TITLE
cleanup help command to make it a bit more usable

### DIFF
--- a/bot/commands/information/help.js
+++ b/bot/commands/information/help.js
@@ -103,7 +103,7 @@ function helpCommand(message, args, config) {
 
     if (name === 'categories' || name === undefined) {
         const categoryNames = categories.map((c) => `\`${c}\``).join(', ');
-        return sendMessage(message.channel, `Since there are a large number of messages please pick a specific category of commands to view, valid categories to get help for are: \`all\`, ${categoryNames}`);
+        return sendMessage(message.channel, `Botomir has a lot of commands, to reduce the amount of spam please specify a category you would like some help with, valid categories to get help for are: \`all\`, ${categoryNames}`);
     }
 
     if (name === 'all') {
@@ -127,13 +127,13 @@ module.exports = {
     botAdmin: false,
     alwaysEnabled: true,
     description: 'lists all the commands, a category of commands or info about a specific command',
-    usage: "[command or category name or 'categories' or 'all']",
+    usage: "[\`<command>\`| \`<category>\` | \`categories\` | \`all\`]",
     aliases: ['commands'],
     execute: helpCommand,
     docs: `#### Help
 - Command: \`help\`
 - Args:
-    - optional, \`<command>\`| \`<category>\` | \`categories\`
+    - optional, \`<command>\`| \`<category>\` | \`categories\` | \`all\`
 - Returns:
     - list of commands available to Botomir\n'
     - specific information about the passed in command if command specified\n'
@@ -157,7 +157,7 @@ User
 > !help categories
 
 Botomir
-> Valid categories to get help for are: \`admin\`, \`information\`, \`music\`, \`reddit\`, \`roles\`, \`utility\`
+> Botomir has a lot of commands, to reduce the amount of spam please specify a category you would like some help with, valid categories to get help for are: \`all\`, \`admin\`, \`information\`, \`music\`, \`reddit\`, \`roles\`, \`utility\`
 \`\`\`
 \`\`\`
 User

--- a/bot/commands/information/help.js
+++ b/bot/commands/information/help.js
@@ -127,7 +127,7 @@ module.exports = {
     botAdmin: false,
     alwaysEnabled: true,
     description: 'lists all the commands, a category of commands or info about a specific command',
-    usage: "[\`<command>\`| \`<category>\` | \`categories\` | \`all\`]",
+    usage: '[`<command>`| `<category>` | `categories` | `all`]',
     aliases: ['commands'],
     execute: helpCommand,
     docs: `#### Help

--- a/bot/commands/information/help.js
+++ b/bot/commands/information/help.js
@@ -99,14 +99,15 @@ function helpSpecific(message, command, config) {
 function helpCommand(message, args, config) {
     const { commands, categories } = message.client;
 
-    if (args.length === 0) {
-        return helpGeneral(message, commands, config);
-    }
-    const name = args[0].toLowerCase();
+    const name = args.length !== 0 ? args[0].toLowerCase() : undefined;
 
-    if (name === 'categories') {
+    if (name === 'categories' || name === undefined) {
         const categoryNames = categories.map((c) => `\`${c}\``).join(', ');
-        return sendMessage(message.channel, `Valid categories to get help for are: ${categoryNames}`);
+        return sendMessage(message.channel, `Since there are a large number of messages please pick a specific category of commands to view, valid categories to get help for are: \`all\`, ${categoryNames}`);
+    }
+
+    if (name === 'all') {
+        return helpGeneral(message, commands, config);
     }
 
     const command = commands.get(name)
@@ -117,7 +118,7 @@ function helpCommand(message, args, config) {
     const categoryCommands = commands.filter((c) => c.category === name);
     if (categoryCommands.size !== 0) return helpGeneral(message, categoryCommands, config, name);
 
-    return sendMessage(message.channel, `${name} is not a valid command or cagtegory!`);
+    return sendMessage(message.channel, `${name} is not a valid command or category!`);
 }
 
 module.exports = {
@@ -126,7 +127,7 @@ module.exports = {
     botAdmin: false,
     alwaysEnabled: true,
     description: 'lists all the commands, a category of commands or info about a specific command',
-    usage: '[command or category name or ``]',
+    usage: "[command or category name or 'categories' or 'all']",
     aliases: ['commands'],
     execute: helpCommand,
     docs: `#### Help


### PR DESCRIPTION
The help command had a couple of little issues and would spam the channel it gets sent in because of how many commands there are, this should improve that. 


---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Add automated tests cases
- [x] Run `npm run lint-fix` and ensure linter is still passing
- [x] Verify that all automated tests pass
- [x] Verify that the changes work as expected on Discord
- [ ] Update the README and other applicable documentation pages
- [ ] Update the changelog
