### PR TITLE
Add bot notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ services:
       - SPOTIFY_CLIENT_ID: '1234567890'
       - SPOTIFY_CLIENT_SECRET: abcde234543
       - BASE_URL: 'https://botomir.com'
+      - BOTOMIR_NOTIFICATION_GUILD: '1029384756'
+      - BOTOMIR_NOTIFICATION_CHANNEL: '1234567890'
       - MODE: production
     ports:
       - "80:8300"
@@ -67,7 +69,7 @@ Or run `docker run -p 80:8300 -e DISCORD_TOKEN=token .... --name botomir marshal
 - embedded Links
 - read message history
 
-In order to use any of the bot configuration commands you must have the role `botmir-admin` assigned to you.
+In order to use any of the bot configuration commands you must have the role `botomir-admin` assigned to you.
 
 ## Features
 

--- a/bot/index.js
+++ b/bot/index.js
@@ -7,7 +7,7 @@ const { scannerHandler } = source('bot/scanner/botScanner');
 const { databaseHandler } = source('bot/scanner/messageLogger');
 const { addReactionHandler, removeReactionHandler } = source('bot/reactions/botReactions');
 const logger = source('bot/utils/logger');
-const { sendMessage } = source('bot/utils/util');
+const { sendMessage, sendEventMessage } = source('bot/utils/util');
 
 const client = new Discord.Client({
     partials: ['MESSAGE', 'CHANNEL', 'REACTION'],
@@ -20,7 +20,7 @@ client.once('ready', () => {
 
 client.on('message', (message) => {
     if (message.guild === null) {
-        logger.warn('message recieved in a DM');
+        logger.warn('message received in a DM');
         if (!message.author.bot) sendMessage(message.channel, 'This bot can only be used in servers, not DM\'s');
         return;
     }
@@ -37,11 +37,18 @@ client.on('message', (message) => {
 // joined a server
 client.on('guildCreate', (guild) => {
     logger.info(`Joined a new guild: ${guild.name}`);
+    sendEventMessage(client, `Botomir has joined the \`${guild.name}\` guild!! We are now in ${client.guilds.cache.size} guilds`);
+});
+
+// removed from a server
+client.on('guildDelete', (guild) => {
+    logger.info(`removed from a guild: ${guild.name}`);
+    sendEventMessage(client, `Botomir has left \`${guild.name}\` :cry:  We are now in ${client.guilds.cache.size} guilds`);
 });
 
 client.on('messageReactionAdd', (reaction, user) => {
     if (reaction.message.guild === null) {
-        logger.warn('reaction recieved in a DM');
+        logger.warn('reaction received in a DM');
         return;
     }
 
@@ -50,7 +57,7 @@ client.on('messageReactionAdd', (reaction, user) => {
 
 client.on('messageReactionRemove', (reaction, user) => {
     if (reaction.message.guild === null) {
-        logger.warn('reaction recieved in a DM');
+        logger.warn('reaction received in a DM');
         return;
     }
 
@@ -60,6 +67,8 @@ client.on('messageReactionRemove', (reaction, user) => {
 client.on('error', (err) => {
     logger.error(`bot encountered error {${err}}`);
     logger.error(err);
+    sendEventMessage(client, `Oh no something went wrong!!! {${err}}`);
+
     logger.warn('attempting to login to discord again');
     client.login(process.env.DISCORD_TOKEN).then(() => logger.info('Login successful'));
 });

--- a/bot/utils/util.js
+++ b/bot/utils/util.js
@@ -15,6 +15,22 @@ function sendMessage(channel, message) {
         .catch((e) => logger.error(`could not send message:, ${e.message}`));
 }
 
+function sendEventMessage(client, message) {
+
+    const notificationGuildID = process.env.BOTOMIR_NOTIFICATION_GUILD;
+    const notificationChannelID = process.env.BOTOMIR_NOTIFICATION_CHANNEL;
+
+    if (!notificationGuildID || !notificationChannelID) {
+        logger.info('Bot notification channel is not configured');
+        return;
+    }
+
+    return client.guilds.fetch(notificationGuildID)
+        .then((guild) => guild.channels.cache.get(notificationChannelID))
+        .then((channel) => sendMessage(channel, message))
+        .catch((e) => logger.error('Error: encountered error when fetching guilds:', e));
+}
+
 function trimDiscordID(string) {
     if (!string) return undefined;
 
@@ -45,4 +61,5 @@ module.exports = {
     getChannel,
     lookupRoleName,
     getMember,
+    sendEventMessage,
 };

--- a/bot/utils/util.js
+++ b/bot/utils/util.js
@@ -16,13 +16,11 @@ function sendMessage(channel, message) {
 }
 
 function sendEventMessage(client, message) {
-
     const notificationGuildID = process.env.BOTOMIR_NOTIFICATION_GUILD;
     const notificationChannelID = process.env.BOTOMIR_NOTIFICATION_CHANNEL;
 
     if (!notificationGuildID || !notificationChannelID) {
-        logger.info('Bot notification channel is not configured');
-        return;
+        return logger.info('Bot notification channel is not configured');
     }
 
     return client.guilds.fetch(notificationGuildID)

--- a/template.env
+++ b/template.env
@@ -11,6 +11,9 @@ DISCORD_CLIENT_SECRET=<discord app secret>
 
 SESSION_SECRET=<a random secret string>
 
+BOTOMIR_NOTIFICATION_GUILD=<GUILD ID to send event notifications to>
+BOTOMIR_NOTIFICATION_CHANNEL=<channel to send event notifications to>
+
 # this will limit logging in production and will improve caching efficiency
 NODE_ENV=production
 BOT_MODS=<the name or handle of the bot admins>


### PR DESCRIPTION
It would be useful to get a notification when certain bot events happen, now we can. 

This adds the `sendEventMessage()` function which can send a message to a notification channel when events occur. 

Currently it is set to only send the event when botomir is added/ removed from a guild or when a discordjs error occurs. 
---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Add automated tests cases
- [x] Run `npm run lint-fix` and ensure linter is still passing
- [x] Verify that all automated tests pass
- [x] Verify that the changes work as expected on Discord
- [x] Update the README and other applicable documentation pages
- [ ] Update the changelog
